### PR TITLE
fix MQTT packet corruption error if serial number contains non-printable characters

### DIFF
--- a/radoneye-reader.py
+++ b/radoneye-reader.py
@@ -28,6 +28,8 @@ class RadonEyeParser:
 
     def parse_sensor_data(self, data: bytearray) -> dict:
         serial = self.read_str(data, 8, 3) + self.read_str(data, 2, 6) + self.read_str(data, 11, 4)
+        # seen serial contain a 0x07 (Bell) character, which might confuse MQTT, so strip it.
+        serial = ''.join(i for i in serial if i.isprintable())
         model = self.read_str(data, 16, 6)
         version = self.read_str(data, 22, 6)
         latest_bq_m3 = self.read_short(data, 33)

--- a/radoneye-reader.py
+++ b/radoneye-reader.py
@@ -234,7 +234,7 @@ class RadonEyeReaderApp:
 
     def mqtt_init(self):
         if self.args.mqtt:
-            self.mqttc = mqtt.Client("radoneye_{hostname}".format(hostname=socket.gethostname()), callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
+            self.mqttc = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id="radoneye_{hostname}".format(hostname=socket.gethostname()))
 
             if self.args.debug:
                 self.mqttc.enable_logger()

--- a/radoneye-reader.py
+++ b/radoneye-reader.py
@@ -234,7 +234,7 @@ class RadonEyeReaderApp:
 
     def mqtt_init(self):
         if self.args.mqtt:
-            self.mqttc = mqtt.Client("radoneye_{hostname}".format(hostname=socket.gethostname()))
+            self.mqttc = mqtt.Client("radoneye_{hostname}".format(hostname=socket.gethostname()), callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
 
             if self.args.debug:
                 self.mqttc.enable_logger()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 asyncio~=3.4.3
 bleak~=0.21.1
-paho-mqtt~=1.6.1
+paho-mqtt~=2.1.0


### PR DESCRIPTION
My device returns the serial number string with a 0x07 (bell) character at the end, which caused mosquitto to reject the packets that contain the serial in the topic as malformed. This strips the serial number string.

As an aside, update paho-mqtt to v2.1.0